### PR TITLE
fix:cotovia_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To use the `'sabela'` voice you also need to install `cotovia`, follow the steps
 
 ## Configuration
 
+valid voices are  `'celtia'` and  `'sabela'`
+
 ```json
   "tts": {
     "module": "ovos-tts-plugin-nos",
@@ -20,7 +22,19 @@ To use the `'sabela'` voice you also need to install `cotovia`, follow the steps
  
 ```
 
-valid voices are  `'celtia'` and  `'sabela'`
+If using voice `sabela`, `bin` can be used to set a path to the `cotovia` executable (default `/usr/bin/cotovia`)
+
+```json
+  "tts": {
+    "module": "ovos-tts-plugin-nos",
+    "ovos-tts-plugin-nos": {
+      "voice": "sabela",
+      "bin": "/usr/bin/cotovia"
+    }
+   }
+ 
+```
+
 
 ## Credits
 

--- a/ovos_tts_plugin_nos/__init__.py
+++ b/ovos_tts_plugin_nos/__init__.py
@@ -21,7 +21,7 @@ class NosTTSPlugin(TTS):
         super().__init__(lang=lang, config=config, audio_ext='wav')
         if self.voice == "default":
             self.voice = "celtia"
-        self.cotovia = CotoviaTTSPlugin()
+        self.cotovia = CotoviaTTSPlugin(lang=lang, config=config)
 
     @staticmethod
     def download(url):


### PR DESCRIPTION
allow passing cotovia binary via config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated documentation to clarify usage of the 'sabela' voice in text-to-speech configuration.
	- Introduced a new configuration option for the 'sabela' voice, allowing users to specify the path to the `cotovia` executable.
	- Added a new configuration example demonstrating the use of the 'sabela' voice with the `bin` parameter.

- **Bug Fixes**
	- Enhanced flexibility in initializing the `CotoviaTTSPlugin` with language and configuration parameters for better adaptability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->