### PR TITLE
fix: pin working onnxruntime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 scipy
-onnxruntime
+onnxruntime<=1.20.1
 ovos-tts-plugin-cotovia


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to restrict the onnxruntime package to versions up to 1.20.1.
  - Retained the existing configuration for the text-to-speech plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->